### PR TITLE
Accept bytestring 0.11

### DIFF
--- a/postgresql-migration.cabal
+++ b/postgresql-migration.cabal
@@ -55,7 +55,7 @@ library
   default-language:       Haskell2010
   build-depends:          base                        >= 4.9      && < 5.0
                         , base64-bytestring           >= 1.0      && < 1.3
-                        , bytestring                  >= 0.10     && < 0.11
+                        , bytestring                  >= 0.10     && < 0.12
                         , cryptohash                  >= 0.11     && < 0.12
                         , directory                   >= 1.2      && < 1.4
                         , filepath                    >= 1.4.1.0  && < 1.4.3.0


### PR DESCRIPTION
Bump the dependency bound on `bytestring` to accept  version 0.11