### PR TITLE
Add log statement before executing file

### DIFF
--- a/src/Database/PostgreSQL/Simple/Migration.hs
+++ b/src/Database/PostgreSQL/Simple/Migration.hs
@@ -173,9 +173,10 @@ executeMigration con opts name contents = doStepTransaction opts con $ do
       when (verbose opts) $ optLogWriter opts $ Right $ "Ok:\t" <> fromString name
       pure MigrationSuccess
     ScriptNotExecuted -> do
+      when (verbose opts) $ optLogWriter opts $ Right ("Executing:\t" <> fromString name)
       void $ execute_ con (Query contents)
       void $ execute con q (name, checksum)
-      when (verbose opts) $ optLogWriter opts $ Right ("Execute:\t" <> fromString name)
+      when (verbose opts) $ optLogWriter opts $ Right ("Executed:\t" <> fromString name)
       pure MigrationSuccess
     ScriptModified eva -> do
       when (verbose opts) $ optLogWriter opts $ Left ("Fail:\t" <> fromString name <> "\n" <> scriptModifiedErrorMessage eva)


### PR DESCRIPTION
If a script throws an exception,
you know exactly now which one was running.