### PR TITLE
Escape table name to prevent SQL injection via optTableName option

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -29,19 +29,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.1
+          - compiler: ghc-9.6.3
             compilerKind: ghc
-            compilerVersion: 9.6.1
+            compilerVersion: 9.6.3
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.4
+          - compiler: ghc-9.4.7
             compilerKind: ghc
-            compilerVersion: 9.4.4
+            compilerVersion: 9.4.7
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.7
+          - compiler: ghc-9.2.8
             compilerKind: ghc
-            compilerVersion: 9.2.7
+            compilerVersion: 9.2.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -66,15 +66,15 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 postgresql-client
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
           HCVER: ${{ matrix.compilerVersion }}
-
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
@@ -82,11 +82,14 @@ jobs:
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
-          HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
           echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
           echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -89,7 +89,6 @@ jobs:
           echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
           echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
           echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"

--- a/postgresql-migration.cabal
+++ b/postgresql-migration.cabal
@@ -12,9 +12,9 @@ copyright:                  2014-2021, Andreas Meingast
 category:                   Database
 build-type:                 Simple
 description:                A PostgreSQL-simple schema migration utility
-tested-with:                GHC==9.6.1
-                            GHC==9.4.4
-                            GHC==9.2.7
+tested-with:                GHC==9.6.3
+                            GHC==9.4.7
+                            GHC==9.2.8
                             GHC==9.0.2
                             GHC==8.8.4
                             GHC==8.6.5

--- a/src/Database/PostgreSQL/Simple/Migration.hs
+++ b/src/Database/PostgreSQL/Simple/Migration.hs
@@ -217,7 +217,7 @@ executeValidation
 executeValidation con opts cmd = doStepTransaction opts con $
   case cmd of
     MigrationInitialization ->
-      existsTable con (migrationsTableName opts) <&> \r -> if r
+      existsTable con (BS8.unpack $ optTableName opts) <&> \r -> if r
         then MigrationSuccess
         else MigrationError ("No such table: " <> BS8.unpack (optTableName opts))
     MigrationDirectory path ->

--- a/src/Database/PostgreSQL/Simple/Migration.hs
+++ b/src/Database/PostgreSQL/Simple/Migration.hs
@@ -62,7 +62,7 @@ import           Database.PostgreSQL.Simple ( Connection
 import           Database.PostgreSQL.Simple.FromRow (FromRow (..), field)
 import           Database.PostgreSQL.Simple.ToField (ToField (..))
 import           Database.PostgreSQL.Simple.ToRow (ToRow (..))
-import           Database.PostgreSQL.Simple.Types (Query (..))
+import           Database.PostgreSQL.Simple.Types (Query (..), Identifier)
 import           Database.PostgreSQL.Simple.Util (existsTable)
 import           System.Directory (listDirectory)
 import           System.FilePath ((</>))
@@ -176,22 +176,24 @@ executeMigration con opts name contents = doStepTransaction opts con $ do
       when (verbose opts) $ optLogWriter opts $ Right ("Executing:\t" <> fromString name)
       void $ execute_ con (Query contents)
       when (verbose opts) $ optLogWriter opts $ Right ("Adding '" <> fromString name <> "' to schema_migrations with checksum '" <> fromString (show checksum) <> "'")
-      void $ execute con q (name, checksum)
+      void $ execute con q (migrationsTableName opts, name, checksum)
       when (verbose opts) $ optLogWriter opts $ Right ("Executed:\t" <> fromString name)
       pure MigrationSuccess
     ScriptModified eva -> do
       when (verbose opts) $ optLogWriter opts $ Left ("Fail:\t" <> fromString name <> "\n" <> scriptModifiedErrorMessage eva)
       pure (MigrationError name)
   where
-    q = "insert into " <> Query (optTableName opts) <> "(filename, checksum) values(?, ?)"
+    q = "insert into ? (filename, checksum) values(?, ?)"
 
 -- | Initializes the database schema with a helper table containing
 -- meta-information about executed migrations.
 initializeSchema :: Connection -> MigrationOptions -> IO ()
 initializeSchema con opts = do
   when (verbose opts) $ optLogWriter opts $ Right "Initializing schema"
-  void . doStepTransaction opts con . execute_ con $ mconcat
-      [ "create table if not exists " <> Query (optTableName opts) <> " "
+  void . doStepTransaction opts con $ execute con q (Only $ migrationsTableName opts)
+  where
+    q = mconcat
+      [ "create table if not exists ? "
       , "( filename varchar(512) not null"
       , ", checksum varchar(32) not null"
       , ", executed_at timestamp without time zone not null default now() "
@@ -215,7 +217,7 @@ executeValidation
 executeValidation con opts cmd = doStepTransaction opts con $
   case cmd of
     MigrationInitialization ->
-      existsTable con (BS8.unpack $ optTableName opts) <&> \r -> if r
+      existsTable con (migrationsTableName opts) <&> \r -> if r
         then MigrationSuccess
         else MigrationError ("No such table: " <> BS8.unpack (optTableName opts))
     MigrationDirectory path ->
@@ -252,7 +254,7 @@ executeValidation con opts cmd = doStepTransaction opts con $
 -- will be executed and its meta-information will be recorded.
 checkScript :: Connection -> MigrationOptions -> ScriptName -> Checksum -> IO CheckScriptResult
 checkScript con opts name fileChecksum =
-  query con q (Only name) >>= \case
+  query con q (migrationsTableName opts, name) >>= \case
     [] ->
       pure ScriptNotExecuted
     Only dbChecksum:_ | fileChecksum == dbChecksum ->
@@ -261,7 +263,7 @@ checkScript con opts name fileChecksum =
       pure $ ScriptModified (ExpectedVsActual {evaExpected = dbChecksum, evaActual = fileChecksum})
   where
     q = mconcat
-        [ "select checksum from " <> Query (optTableName opts) <> " "
+        [ "select checksum from ? "
         , "where filename = ? limit 1"
         ]
 
@@ -372,6 +374,11 @@ defaultOptions =
     , optLogWriter = either (T.hPutStrLn stderr) T.putStrLn
     , optTransactionControl = TransactionPerRun
     }
+
+-- Wrap the name of the table that stores migrations into Identifier,
+-- to ensure it's properly escaped (prevent SQL injection via optTableName)
+migrationsTableName :: MigrationOptions -> Identifier
+migrationsTableName = fromString . BS8.unpack . optTableName
 
 verbose :: MigrationOptions -> Bool
 verbose o = optVerbose o == Verbose

--- a/src/Database/PostgreSQL/Simple/Util.hs
+++ b/src/Database/PostgreSQL/Simple/Util.hs
@@ -17,6 +17,7 @@ module Database.PostgreSQL.Simple.Util
     ) where
 
 import           Control.Exception ( finally )
+import           Database.PostgreSQL.Simple.Types (Identifier)
 import           Database.PostgreSQL.Simple ( Connection
                                             , Only (..)
                                             , begin
@@ -26,7 +27,7 @@ import           Database.PostgreSQL.Simple ( Connection
 import           GHC.Int (Int64)
 
 -- | Checks if the table with the given name exists in the database.
-existsTable :: Connection -> String -> IO Bool
+existsTable :: Connection -> Identifier -> IO Bool
 existsTable con table =
   checkRowCount <$> (query con q (Only table) :: IO [[Int64]])
   where

--- a/src/Database/PostgreSQL/Simple/Util.hs
+++ b/src/Database/PostgreSQL/Simple/Util.hs
@@ -17,7 +17,6 @@ module Database.PostgreSQL.Simple.Util
     ) where
 
 import           Control.Exception ( finally )
-import           Database.PostgreSQL.Simple.Types (Identifier)
 import           Database.PostgreSQL.Simple ( Connection
                                             , Only (..)
                                             , begin
@@ -27,7 +26,7 @@ import           Database.PostgreSQL.Simple ( Connection
 import           GHC.Int (Int64)
 
 -- | Checks if the table with the given name exists in the database.
-existsTable :: Connection -> Identifier -> IO Bool
+existsTable :: Connection -> String -> IO Bool
 existsTable con table =
   checkRowCount <$> (query con q (Only table) :: IO [[Int64]])
   where

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.21
+resolver: lts-20.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 401a0e813162ba62f04517f60c7d25e93a0f867f94a902421ebf07d1fb5a8c46
-    size: 650044
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/21.yaml
-  original: lts-20.21
+    sha256: 5a59b2a405b3aba3c00188453be172b85893cab8ebc352b1ef58b0eae5d248a2
+    size: 650475
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/26.yaml
+  original: lts-20.26


### PR DESCRIPTION
It is a bad practice to concatenate user input directly into query. This opens easily exploitable SQL injection vulnerabilities.

A proper way to do it is to interpolate table name into query as you'd interpolate other arguments as [Identifier](https://hackage.haskell.org/package/postgresql-simple-0.7.0.0/docs/Database-PostgreSQL-Simple-Types.html#t:Identifier) whose ToField instance makes sure that table name is properly quoted/escaped.